### PR TITLE
Correct a TypeError exception

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -619,7 +619,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
 
     def _query_hf_dataset(self, query_indices: dict[str, list[int]]) -> dict:
         return {
-            key: torch.stack(self.hf_dataset.select(q_idx)[key])
+            key: torch.stack([t.detach().clone() for t in self.hf_dataset.select(q_idx)[key]])
             for key, q_idx in query_indices.items()
             if key not in self.meta.video_keys
         }

--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -407,7 +407,7 @@ def check_timestamps_sync(
     This check is to make sure that each timestamps is separated to the next by 1/fps +/- tolerance to
     account for possible numerical error.
     """
-    timestamps = torch.stack(hf_dataset["timestamp"])
+    timestamps = torch.stack([torch.tensor(t) for t in hf_dataset["timestamp"]])
     diffs = torch.diff(timestamps)
     within_tolerance = torch.abs(diffs - 1 / fps) <= tolerance_s
 
@@ -425,7 +425,7 @@ def check_timestamps_sync(
         filtered_indices = original_indices[mask]
         outside_tolerance_filtered_indices = torch.nonzero(~filtered_within_tolerance)  # .squeeze()
         outside_tolerance_indices = filtered_indices[outside_tolerance_filtered_indices]
-        episode_indices = torch.stack(hf_dataset["episode_index"])
+        episode_indices = torch.stack([torch.tensor(t) for t in hf_dataset["episode_index"]])
 
         outside_tolerances = []
         for idx in outside_tolerance_indices:


### PR DESCRIPTION
## Correct a TypeError exception
Here is what was happening:
```
    timestamps = torch.stack(hf_dataset["timestamp"])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: stack(): argument 'tensors' (position 1) must be tuple of Tensors, not Column
```

I'm not sure it is the correct way to solve the problem, though.

## How it was tested
Execution goes further

